### PR TITLE
Login, Navbar, Dashboard Setup

### DIFF
--- a/src/components/AlbumCovers.js
+++ b/src/components/AlbumCovers.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Box from '@mui/material/Box';
+
+export const AlbumCovers = () => {
+  return (
+    <Box>
+      AlbumCovers
+    </Box>
+  );
+}

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,15 @@
+import React from 'react';
+
+import { LyricQuote } from './LyricQuote';
+import { AlbumCovers } from './AlbumCovers';
+
+import Box from '@mui/material/Box';
+
 export const Dashboard = () => {
     return (
-      <div>
-        Dashboard
-      </div>
+      <Box>
+        <LyricQuote />
+        <AlbumCovers />
+      </Box>
     );
   }

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -5,11 +5,13 @@ import { AlbumCovers } from './AlbumCovers';
 
 import Box from '@mui/material/Box';
 
-export const Dashboard = () => {
-    return (
-      <Box>
-        <LyricQuote />
-        <AlbumCovers />
-      </Box>
-    );
-  }
+export const Dashboard = props => {
+  const topTracks = props.topTracks;
+
+  return (
+    <Box>
+      <LyricQuote />
+      <AlbumCovers />
+    </Box>
+  );
+}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -7,6 +7,7 @@ import { NavigationBar } from "./NavigationBar";
 
 import Box from '@mui/material/Box';
 import { Link } from "@mui/material";
+import Typography from '@mui/material/Typography';
 
 export const Home = () => {
   const SPOTIFY_CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID
@@ -79,9 +80,12 @@ export const Home = () => {
       <NavigationBar token={token} logout={logout} user={user} />
         <Box sx={{ height: '100vh' }}> 
           { token ?
-            <Dashboard />
+            <Dashboard topTracks={topTracks} />
           :
-            <Box sx={{ display: 'flex', justifyContent: 'center', height: '75%', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', flexDirection:'column', justifyContent: 'center', height: '75%', alignItems: 'center' }}>
+              <Typography variant="h2" gutterBottom>
+                MySpotifyProfile
+              </Typography>
               <Link 
                 href={loginURL} 
                 underline="none" 

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,16 +1,29 @@
 import React from "react";
 import { useState, useEffect } from "react";
+import axios from 'axios';
+
 import { Dashboard } from "./Dashboard";
 import { NavigationBar } from "./NavigationBar";
 
+import Box from '@mui/material/Box';
+import { Link } from "@mui/material";
+
 export const Home = () => {
   const SPOTIFY_CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID
-  const SPOTIFY_CLIENT_SECRET = process.env.REACT_APP_SPOTIFY_CLIENT_SECRET
   const SPOTIFY_AUTH_ENDPOINT = process.env.REACT_APP_SPOTIFY_AUTH_ENDPOINT
   const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI
   const RESPONSE_TYPE = "token"
+  const loginURL = `${SPOTIFY_AUTH_ENDPOINT}?client_id=${SPOTIFY_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=${RESPONSE_TYPE}&scope=user-top-read`
 
   const [token, setToken] = useState('')
+  const [user, setUser] = useState(null)
+  const [topTracks, setTopTracks] = useState([])
+
+  const logout = () => {
+    setToken('')
+    window.localStorage.removeItem('token')
+    setUser(null)
+  }
 
   useEffect(() => {
     const hash = window.location.hash
@@ -27,21 +40,65 @@ export const Home = () => {
 
   }, [])
 
-  const logout = () => {
-    setToken('')
-    window.localStorage.removeItem('token')
-  }
+  useEffect(() => {
+    if (token) {
+      const getUser = () => {
+        axios.get('https://api.spotify.com/v1/me', {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": 'application/json'
+            },
+        }).then((res) => {
+          setUser(res.data)
+        })
+      }
+
+      const getTopTracks = () => {
+        const params = {
+          limit: 10
+        }
+
+        axios.get('https://api.spotify.com/v1/me/top/tracks', {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": 'application/json'
+            },
+            params: params
+        }).then((res) => {
+          setTopTracks([...res.data.items])
+        })
+      }
+
+      getUser()
+      getTopTracks()
+    }
+  }, [token])
 
   return (
-    <div>
-      <NavigationBar token={token} logout={logout} />
-        <div> 
+    <Box>
+      <NavigationBar token={token} logout={logout} user={user} />
+        <Box sx={{ height: '100vh' }}> 
           { token ?
             <Dashboard />
           :
-            <a href={`${SPOTIFY_AUTH_ENDPOINT}?client_id=${SPOTIFY_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=${RESPONSE_TYPE}`}>Login to Spotify</a>
+            <Box sx={{ display: 'flex', justifyContent: 'center', height: '75%', alignItems: 'center' }}>
+              <Link 
+                href={loginURL} 
+                underline="none" 
+                sx={{ 
+                  fontSize: 24,
+                  color: '#E0E1DD',
+                  background: '#778DA9',
+                  width: '100px',
+                  padding: '10px',
+                  borderRadius: '15px',
+                  textAlign: 'center'
+                }}>
+                {'Login'}
+              </Link>
+            </Box>
           }
-        </div>
-    </div>
+        </Box>
+    </Box>
   );
 }

--- a/src/components/LyricQuote.js
+++ b/src/components/LyricQuote.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Box from '@mui/material/Box';
+
+export const LyricQuote = () => {
+  return (
+    <Box>
+      LyricQuote
+    </Box>
+  );
+}

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -1,5 +1,6 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { useState } from 'react';
+
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
@@ -16,8 +17,18 @@ const settings = ['Logout'];
 export const NavigationBar = (props) => {
   const token = props.token
   const logout = props.logout
+  const user = props.user
   
   const [anchorElUser, setAnchorElUser] = useState(null);
+  const [username, setUsername] = useState(null);
+  const [userProfileImage, setUserProfileImage] = useState(null);
+
+  useEffect(() => {
+    if (user) {
+      setUsername(user.id)
+      setUserProfileImage(user.images[0].url)
+    }
+  }, [user])
 
   const handleOpenUserMenu = (event) => {
     setAnchorElUser(event.currentTarget);
@@ -30,6 +41,8 @@ export const NavigationBar = (props) => {
   const handleMenuItemClick = (action) => {
     if (action === 'Logout') {
       logout()
+      setUsername(null)
+      setUserProfileImage(null)
     }
   }
 
@@ -42,15 +55,20 @@ export const NavigationBar = (props) => {
           </Box>
 
           <Box sx={{ flexGrow: 0 }}>
-            { token ?
-              <Tooltip title="Open settings">
-                <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                  <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
-                </IconButton>
-              </Tooltip>
-            :
-              null 
-            }
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <Typography variant="h5" gutterBottom component="div" sx={{ p: 2, pb: 0, fontSize: 22 }}>
+                {username}
+              </Typography>
+              { token ?
+                <Tooltip title="Open settings">
+                  <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+                    <Avatar alt="Profile Picture" src={userProfileImage ? userProfileImage : null} />
+                  </IconButton>
+                </Tooltip>
+              :
+                null 
+              }
+            </Box>
             <Menu
               sx={{ mt: '45px' }}
               id="menu-appbar"

--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,4 @@
 body {
   background-color: #242D3E;
+  color: #E0E1DD;
 }


### PR DESCRIPTION
This PR adds the following changes:
- simple styled login page
- display user's Spotify username and profile picture in navbar
- clicking on user's profile picture will display menu with logout button
- call Spotify API's top tracks to retrieve user's top 10 tracks
- set up dashboard components (lyrics and album cover sections)